### PR TITLE
Reset some counters every time a new content type is synchronized

### DIFF
--- a/src/Console/Commands/AbstractSyncCommand.php
+++ b/src/Console/Commands/AbstractSyncCommand.php
@@ -86,10 +86,10 @@ abstract class AbstractSyncCommand extends Command implements CommandInterface
      */
     public function handle()
     {
-        // Parse options and set defaults
-        $this->ignoreExisting  = (bool)$this->option('ignoreExisting');
-        $this->numSynchronized = 0;
-        $this->skip            = 0;
+        // Parse options and reset counters
+        $this->ignoreExisting = (bool)$this->option('ignoreExisting');
+
+        $this->resetCounters();
     }
 
     /**
@@ -98,5 +98,14 @@ abstract class AbstractSyncCommand extends Command implements CommandInterface
     protected function getClient(): Client
     {
         return $this->contentfulService->getClient();
+    }
+
+    /**
+     * Resets the "skip" and "numSynchronized" counters
+     */
+    protected function resetCounters(): void
+    {
+        $this->numSynchronized = 0;
+        $this->skip            = 0;
     }
 }

--- a/src/Console/Commands/SyncContentsCommand.php
+++ b/src/Console/Commands/SyncContentsCommand.php
@@ -28,7 +28,7 @@ class SyncContentsCommand extends AbstractSyncCommand
     /**
      * @var boolean
      */
-    private $ignoreErrors;
+    protected $ignoreErrors;
 
     /**
      * @inheritdoc
@@ -81,7 +81,7 @@ class SyncContentsCommand extends AbstractSyncCommand
      *
      * @throws \Throwable
      */
-    private function synchronizeContentType(string $contentType)
+    protected function synchronizeContentType(string $contentType)
     {
         $this->info('Synchronizing content of type "' . $contentType . '"...');
 

--- a/src/Console/Commands/SyncContentsCommand.php
+++ b/src/Console/Commands/SyncContentsCommand.php
@@ -69,6 +69,9 @@ class SyncContentsCommand extends AbstractSyncCommand
         $contentTypes = $contentType !== null ? [$contentType] : $this->contentTypes;
 
         foreach ($contentTypes as $contentType) {
+            // Reset counters before each content type
+            $this->resetCounters();
+
             $this->synchronizeContentType($contentType);
         }
     }


### PR DESCRIPTION
Without this the "skip" parameter won't ever get reset, which means syncing multiple content types silently breaks