### PR TITLE
Provide a getTotalQuery() implementation

### DIFF
--- a/src/Console/Commands/AbstractSyncCommand.php
+++ b/src/Console/Commands/AbstractSyncCommand.php
@@ -58,7 +58,13 @@ abstract class AbstractSyncCommand extends Command implements CommandInterface
      *
      * @return Query the query used to get the total number of items
      */
-    abstract protected function getTotalQuery(?string $contentType = null): Query;
+    protected function getTotalQuery(?string $contentType = null): Query
+    {
+        $query = clone $this->getQuery($contentType);
+
+        return $query->setSkip(0)
+                     ->setLimit(1);
+    }
 
     /**
      * AbstractSyncCommand constructor.

--- a/src/Console/Commands/SyncAssetsCommand.php
+++ b/src/Console/Commands/SyncAssetsCommand.php
@@ -39,17 +39,6 @@ class SyncAssetsCommand extends AbstractSyncCommand
     /**
      * @inheritdoc
      */
-    protected function getTotalQuery(?string $contentType = null): Query
-    {
-        $query = new Query();
-        $query->setLimit(1);
-
-        return $query;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function handle()
     {
         parent::handle();

--- a/src/Console/Commands/SyncContentsCommand.php
+++ b/src/Console/Commands/SyncContentsCommand.php
@@ -45,18 +45,6 @@ class SyncContentsCommand extends AbstractSyncCommand
     /**
      * @inheritdoc
      */
-    protected function getTotalQuery(?string $contentType = null): Query
-    {
-        $query = new Query();
-        $query->setLimit(1);
-        $query->setContentType($contentType);
-
-        return $query;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function handle()
     {
         parent::handle();


### PR DESCRIPTION
This way the method doesn't have to be abstract